### PR TITLE
Mark chapter header with epub:type and xml:lang

### DIFF
--- a/src/epub/text/chapter-63.xhtml
+++ b/src/epub/text/chapter-63.xhtml
@@ -9,7 +9,7 @@
 		<section data-parent="book-8" id="chapter-63" epub:type="chapter">
 			<header>
 				<h3 epub:type="title z3998:roman ordinal">LXIII</h3>
-				<blockquote>
+				<blockquote epub:type="epigraph" xml:lang="de">
 					<p>Moses, trotz seiner Befeindung der Kunst, dennoch selber ein großer Künstler war und den wahren Künstlergeist besaß. Nur war dieser Künstlergeist bei ihm, wie bei seinen ägyptischen Landsleuten, nur auf das Kolossale und Unverwüstliche gerichtet. Aber nicht wie die Ägypter formierte er seine Kunstwerke aus Backstein und Granit, sondern er baute Menschenpyramiden, er meisselte Menschenobelisken, er nahm einen armen Hirtenstamm und schuf daraus ein Volk, das ebenfalls den Jahrhunderten trotzen sollte⁠ ⁠… er schuf Israel!</p>
 					<cite>Heine: <i epub:type="se:name.publication.book">Gestandnisse</i></cite>
 				</blockquote>


### PR DESCRIPTION
The only chapter header in this book that doesn’t set `epub:type="epigraph"` and the only foreign‐language one without `xml:lang`.